### PR TITLE
Changes in pr workflow triggers

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    if: github.event.review.state == 'approved'
+    if: ${{ github.event == 'pull_request' || github.event.review.state == 'approved'}}
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,6 +1,8 @@
 name: Build CI
 
 on:
+  pull_request:
+    types: [ opened, reopened ]
   pull_request_review:
     types: [ submitted ]
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,12 +1,12 @@
 name: Build CI
 
 on:
-  pull_request:
-    branches: [ "master" ]
+  pull_request_review:
+    types: [ submitted ]
 
 jobs:
   build:
-
+    if: github.event.review.state == 'approved'
     runs-on: ubuntu-latest
 
     strategy:


### PR DESCRIPTION
Make changes in pr workflow to prevent triggering with every next PR's commit .
- Greatly reduces workflow runs.
- Now pr workflow triggers when PR is opened or approved.